### PR TITLE
Reword a vague sentence in the guidebook

### DIFF
--- a/src/main/resources/assets/integratedterminals/lang/en_us.json
+++ b/src/main/resources/assets/integratedterminals/lang/en_us.json
@@ -178,7 +178,7 @@
 
     "info_book.integratedterminals.storage_terminal.power_usage": "Power Users",
     "info_book.integratedterminals.storage_terminal.power_usage.text1": "Power users tend to dislike clicking too much as it takes too much time. The &lStorage Terminal&r offers a couple of &ohotkeys&r to speed up the usage of common tasks such as selecting the search field, browsing through tabs, clearing the crafting grid, and balancing crafting grid slots. These hotkeys are listed at the end of this section.",
-    "info_book.integratedterminals.storage_terminal.power_usage.text2": "When you have the JEI mod installed, you will be able to exploit JEI's recipe shift-clicking ability to quickly fill the crafting grid. The source of items is defined by the refill source. Furthermore, you can enable synchronization between the JEI and &lStorage Terminal&r search fields.",
+    "info_book.integratedterminals.storage_terminal.power_usage.text2": "When you have the JEI mod installed, you will be able to exploit JEI's recipe shift-clicking ability to quickly fill the crafting grid. The configured source of the auto-refill mode determines where the items come from. Furthermore, you can enable synchronization between the JEI and &lStorage Terminal&r search fields.",
     "info_book.integratedterminals.storage_terminal.power_usage.text3": "If you are not satisfied with the provided text-based filtering options, you can insert your own &lPredicates&r via &lVariable Cards&r. These should accept the ingredient type as input, and a &9Boolean&0 as ouput.",
 
     "info_book.integratedterminals.storage_terminal.portable": "Portable Terminal",


### PR DESCRIPTION
The sentence about the auto-refill mode source in the guidebook was vague, this is an alternative wording suggestion that hopefully improves the readability.