### PR TITLE
Allow going back from the crafting plan gui to the amount gui

### DIFF
--- a/src/main/java/org/cyclops/integratedterminals/client/gui/container/ContainerScreenTerminalStorageCraftingOptionAmount.java
+++ b/src/main/java/org/cyclops/integratedterminals/client/gui/container/ContainerScreenTerminalStorageCraftingOptionAmount.java
@@ -5,6 +5,7 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.components.Tooltip;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Inventory;
@@ -86,7 +87,7 @@ public class ContainerScreenTerminalStorageCraftingOptionAmount<L, C extends Con
         numberField.setVisible(true);
         numberField.setTextColor(16777215);
         numberField.setCanLoseFocus(true);
-        numberField.setValue("1");
+        numberField.setValue(Integer.toString(numberField.validateNumber(getMenu().getCraftingOptionGuiData().getAmount())));
         addRenderableWidget(numberField);
 
         scrollBar = new WidgetScrollBar(leftPos + 153, topPos + 15, 54,
@@ -108,6 +109,14 @@ public class ContainerScreenTerminalStorageCraftingOptionAmount<L, C extends Con
                 Component.translatable("gui.integratedterminals.terminal_storage.step.next").withStyle(ChatFormatting.YELLOW),
                 (bb) -> calculateCraftingJob(),
                 true));
+
+        ButtonText backButton = new ButtonText(leftPos + 5, topPos + 33, 20, 20,
+                Component.translatable("gui.integratedterminals.terminal_storage.step.back"),
+                Component.literal("<"),
+                (bb) -> returnToTerminalStorage(),
+                true);
+        backButton.setTooltip(Tooltip.create(Component.translatable("gui.integratedterminals.terminal_storage.step.back")));
+        addRenderableWidget(backButton);
     }
 
     @Override

--- a/src/main/java/org/cyclops/integratedterminals/client/gui/container/ContainerScreenTerminalStorageCraftingOptionAmount.java
+++ b/src/main/java/org/cyclops/integratedterminals/client/gui/container/ContainerScreenTerminalStorageCraftingOptionAmount.java
@@ -110,7 +110,7 @@ public class ContainerScreenTerminalStorageCraftingOptionAmount<L, C extends Con
                 (bb) -> calculateCraftingJob(),
                 true));
 
-        ButtonText backButton = new ButtonText(leftPos + 5, topPos + 33, 20, 20,
+        ButtonText backButton = new ButtonText(leftPos + 5, topPos + 33, 15, 20,
                 Component.translatable("gui.integratedterminals.terminal_storage.step.back"),
                 Component.literal("<"),
                 (bb) -> returnToTerminalStorage(),

--- a/src/main/java/org/cyclops/integratedterminals/client/gui/container/ContainerScreenTerminalStorageCraftingPlan.java
+++ b/src/main/java/org/cyclops/integratedterminals/client/gui/container/ContainerScreenTerminalStorageCraftingPlan.java
@@ -117,7 +117,7 @@ public class ContainerScreenTerminalStorageCraftingPlan<L, C extends ContainerTe
 
         addRenderableWidget(new ButtonText(leftPos + 221 + 10 - 50 - 55, topPos + 198, 50, 20,
                 Component.translatable("gui.integratedterminals.terminal_storage.step.back"),
-                Component.translatable("gui.integratedterminals.terminal_storage.step.back").withStyle(ChatFormatting.YELLOW),
+                Component.translatable("gui.integratedterminals.terminal_storage.step.back"),
                 (b) -> returnToCraftingOptionAmount(),
                 true));
 

--- a/src/main/java/org/cyclops/integratedterminals/client/gui/container/ContainerScreenTerminalStorageCraftingPlan.java
+++ b/src/main/java/org/cyclops/integratedterminals/client/gui/container/ContainerScreenTerminalStorageCraftingPlan.java
@@ -9,6 +9,7 @@ import net.minecraft.world.entity.player.Inventory;
 import org.cyclops.cyclopscore.client.gui.component.button.ButtonText;
 import org.cyclops.cyclopscore.client.gui.container.ContainerScreenExtended;
 import org.cyclops.cyclopscore.helper.L10NHelpers;
+import org.cyclops.integratedterminals.IntegratedTerminals;
 import org.cyclops.integratedterminals.Reference;
 import org.cyclops.integratedterminals.api.terminalstorage.crafting.ITerminalCraftingPlan;
 import org.cyclops.integratedterminals.api.terminalstorage.crafting.ITerminalCraftingPlanFlat;
@@ -17,6 +18,7 @@ import org.cyclops.integratedterminals.client.gui.container.component.GuiCraftin
 import org.cyclops.integratedterminals.client.gui.container.component.GuiCraftingPlanToggler;
 import org.cyclops.integratedterminals.core.client.gui.CraftingOptionGuiData;
 import org.cyclops.integratedterminals.inventory.container.ContainerTerminalStorageCraftingPlanBase;
+import org.cyclops.integratedterminals.network.packet.TerminalStorageIngredientOpenCraftingJobAmountGuiPacket;
 import org.lwjgl.glfw.GLFW;
 
 import javax.annotation.Nullable;
@@ -113,6 +115,12 @@ public class ContainerScreenTerminalStorageCraftingPlan<L, C extends ContainerTe
 
         this.guiCraftingPlanToggler.init();
 
+        addRenderableWidget(new ButtonText(leftPos + 221 + 10 - 50 - 55, topPos + 198, 50, 20,
+                Component.translatable("gui.integratedterminals.terminal_storage.step.back"),
+                Component.translatable("gui.integratedterminals.terminal_storage.step.back").withStyle(ChatFormatting.YELLOW),
+                (b) -> returnToCraftingOptionAmount(),
+                true));
+
         addRenderableWidget(buttonConfirm = new ButtonText(leftPos + 221 + 10 - 50, topPos + 198, 50, 20,
                 Component.translatable("gui.integratedterminals.terminal_storage.step.craft"),
                 Component.translatable("gui.integratedterminals.terminal_storage.step.craft").withStyle(ChatFormatting.YELLOW),
@@ -123,12 +131,30 @@ public class ContainerScreenTerminalStorageCraftingPlan<L, C extends ContainerTe
 
     @Override
     public boolean keyPressed(int typedChar, int keyCode, int modifiers) {
+        if (typedChar == GLFW.GLFW_KEY_ESCAPE) {
+            returnToCraftingOptionAmount();
+            return true;
+        }
         if (this.guiCraftingPlan != null && this.guiCraftingPlan.isValid()
                 && (typedChar == GLFW.GLFW_KEY_ENTER || typedChar == GLFW.GLFW_KEY_KP_ENTER)) {
             buttonConfirm.onPress();
             return true;
         }
         return super.keyPressed(typedChar, keyCode, modifiers);
+    }
+
+    /**
+     * Go back to the gui in which the crafting amount can be set.
+     * If no crafting option is known, the terminal itself is opened again.
+     */
+    private void returnToCraftingOptionAmount() {
+        CraftingOptionGuiData data = getMenu().getCraftingOptionGuiData();
+        if (data.getCraftingOption() == null) {
+            returnToTerminalStorage();
+        } else {
+            IntegratedTerminals._instance.getPacketHandler().sendToServer(
+                    new TerminalStorageIngredientOpenCraftingJobAmountGuiPacket(data));
+        }
     }
 
     private void returnToTerminalStorage() {

--- a/src/main/resources/assets/integratedterminals/lang/en_us.json
+++ b/src/main/resources/assets/integratedterminals/lang/en_us.json
@@ -21,6 +21,7 @@
     "gui.integratedterminals.terminal_storage.craftingplan.label.failed.insufficient_crafting_interfaces": "Crafting plan - Insufficient Crafting Interfaces",
     "gui.integratedterminals.terminal_storage.craftingplan.label.running": "Crafting plan - Running",
     "gui.integratedterminals.terminal_storage.step.next": "Next",
+    "gui.integratedterminals.terminal_storage.step.back": "Back",
     "gui.integratedterminals.terminal_storage.step.craft": "Craft",
     "gui.integratedterminals.terminal_storage.step.crafting_plan_calculating": "Calculating crafting plan...",
     "gui.integratedterminals.terminal_storage.stored": "Stored: %s",


### PR DESCRIPTION
Implements CyclopsMC/IntegratedCrafting#140.

The GUIs involved live in this repo, not in IntegratedCrafting, so the fix lands here.

## Problem

In the storage terminal's autocrafting flow (click item → set amount → `Next` → crafting plan), pressing ESC on the crafting plan screen closed the whole GUI instead of stepping back. Neither screen had an explicit back button.

## Changes

`ContainerScreenTerminalStorageCraftingPlan`
- ESC now calls `returnToCraftingOptionAmount()`, which re-opens the amount step server-side through the existing `TerminalStorageIngredientOpenCraftingJobAmountGuiPacket`, passing the same `CraftingOptionGuiData`. When no crafting option is attached, it falls back to the previously unused `returnToTerminalStorage()`.
- Added a `Back` button left of `Craft`, in the free strip between it and the view-toggle button.

`ContainerScreenTerminalStorageCraftingOptionAmount`
- Added a `<` back button (tooltip `Back`) between the `+10`/`-10` buttons, left of the number field, wired to the ESC behaviour that already existed on this screen.
- The amount field now initializes from `getCraftingOptionGuiData().getAmount()` (clamped via `validateNumber`) instead of a hardcoded `"1"`, so the entered amount survives the round trip back from the plan screen.

`lang/en_us.json`
- Added `gui.integratedterminals.terminal_storage.step.back`. Other locales come from Crowdin.

## Note on the shift-click shortcut

Shift-clicking an item jumps straight to the plan, skipping the amount step. Back/ESC from there lands on the amount screen rather than the terminal — one step back in the wizard, which also lets the amount be adjusted. Happy to change it to return to the terminal in that case instead.

## Verification

`./gradlew build spotlessCheck` passes (compile, javadoc, shadowJar, Spotless). `:test` is `NO-SOURCE` on this branch, and game tests only exist on 1.21+. The changes are visual GUI behaviour and were not exercised in a running client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017xtbsQuaXzvi2CpfzksJbp

---
_Generated by [Claude Code](https://claude.ai/code/session_017xtbsQuaXzvi2CpfzksJbp)_