### PR TITLE
Show the crafting machine in crafting option tooltips

### DIFF
--- a/src/main/java/org/cyclops/integratedterminals/api/ingredient/IIngredientComponentTerminalStorageHandler.java
+++ b/src/main/java/org/cyclops/integratedterminals/api/ingredient/IIngredientComponentTerminalStorageHandler.java
@@ -5,6 +5,8 @@ import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.inventory.AbstractContainerMenu;
+import com.mojang.datafixers.util.Either;
+import net.minecraft.network.chat.FormattedText;
 import net.minecraft.world.inventory.tooltip.TooltipComponent;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.network.chat.Component;
@@ -76,12 +78,13 @@ public interface IIngredientComponentTerminalStorageHandler<T, M> {
      * @param mouseX The mouse X position.
      * @param mouseY The mouse Y position.
      * @param additionalTooltipLines The additional tooltip lines to add.
-     * @param additionalTooltipComponent An optional visual tooltip component to render below the tooltip lines.
+     * @param additionalTooltipElements Optional elements to render below the tooltip lines,
+     *                                   which can mix text and visual components.
      */
     @OnlyIn(Dist.CLIENT)
     public void drawInstance(GuiGraphics guiGraphics, T instance, long maxQuantity, @Nullable String label, AbstractContainerScreen gui, ContainerScreenTerminalStorage.DrawLayer layer, float partialTick, int x, int y,
                              int mouseX, int mouseY, @Nullable List<Component> additionalTooltipLines,
-                             @Nullable TooltipComponent additionalTooltipComponent);
+                             @Nullable List<Either<FormattedText, TooltipComponent>> additionalTooltipElements);
 
     /**
      * Show the quantity of the given instance on the second tooltip line.

--- a/src/main/java/org/cyclops/integratedterminals/api/terminalstorage/crafting/ITerminalCraftingOption.java
+++ b/src/main/java/org/cyclops/integratedterminals/api/terminalstorage/crafting/ITerminalCraftingOption.java
@@ -1,5 +1,6 @@
 package org.cyclops.integratedterminals.api.terminalstorage.crafting;
 
+import net.minecraft.world.item.ItemStack;
 import org.cyclops.commoncapabilities.api.ingredient.IIngredientMatcher;
 import org.cyclops.commoncapabilities.api.ingredient.IPrototypedIngredient;
 import org.cyclops.commoncapabilities.api.ingredient.IngredientComponent;
@@ -58,6 +59,15 @@ public interface ITerminalCraftingOption<T> extends Comparable<ITerminalCrafting
      * @return The inputs
      */
     public <T1, M> Collection<T1> getInputs(IngredientComponent<T1, M> ingredientComponent);
+
+    /**
+     * Item representations of the machines that this crafting job option is crafted in.
+     *
+     * @return The crafting machines, can be empty if they are unknown.
+     */
+    public default List<ItemStack> getCraftingMachines() {
+        return Collections.emptyList();
+    }
 
     /**
      * The inputs of this crafting job option for the given ingredient component,

--- a/src/main/java/org/cyclops/integratedterminals/capability/ingredient/IngredientComponentTerminalStorageHandlerEnergy.java
+++ b/src/main/java/org/cyclops/integratedterminals/capability/ingredient/IngredientComponentTerminalStorageHandlerEnergy.java
@@ -10,6 +10,8 @@ import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.Slot;
+import com.mojang.datafixers.util.Either;
+import net.minecraft.network.chat.FormattedText;
 import net.minecraft.world.inventory.tooltip.TooltipComponent;
 import net.minecraft.world.item.ItemStack;
 import net.neoforged.api.distmarker.Dist;
@@ -67,7 +69,7 @@ public class IngredientComponentTerminalStorageHandlerEnergy implements IIngredi
     public void drawInstance(GuiGraphics guiGraphics, Long instance, long maxQuantity, @Nullable String label, AbstractContainerScreen gui,
                              ContainerScreenTerminalStorage.DrawLayer layer, float partialTick, int x, int y,
                              int mouseX, int mouseY, @Nullable List<Component> additionalTooltipLines,
-                             @Nullable TooltipComponent additionalTooltipComponent) {
+                             @Nullable List<Either<FormattedText, TooltipComponent>> additionalTooltipElements) {
         if (instance > 0) {
             if (layer == ContainerScreenTerminalStorage.DrawLayer.BACKGROUND){
 
@@ -103,7 +105,7 @@ public class IngredientComponentTerminalStorageHandlerEnergy implements IIngredi
                                 lines.addAll(additionalTooltipLines);
                             }
                             return lines;
-                        }, additionalTooltipComponent);
+                        }, additionalTooltipElements);
             }
         }
     }

--- a/src/main/java/org/cyclops/integratedterminals/capability/ingredient/IngredientComponentTerminalStorageHandlerFluidStack.java
+++ b/src/main/java/org/cyclops/integratedterminals/capability/ingredient/IngredientComponentTerminalStorageHandlerFluidStack.java
@@ -12,6 +12,8 @@ import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.Slot;
+import com.mojang.datafixers.util.Either;
+import net.minecraft.network.chat.FormattedText;
 import net.minecraft.world.inventory.tooltip.TooltipComponent;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
@@ -74,7 +76,7 @@ public class IngredientComponentTerminalStorageHandlerFluidStack implements IIng
                              ContainerScreenTerminalStorage.DrawLayer layer, float partialTick,
                              int x, int y, int mouseX, int mouseY,
                              @Nullable List<Component> additionalTooltipLines,
-                             @Nullable TooltipComponent additionalTooltipComponent) {
+                             @Nullable List<Either<FormattedText, TooltipComponent>> additionalTooltipElements) {
         if (instance != null) {
             if (layer == ContainerScreenTerminalStorage.DrawLayer.BACKGROUND) {
                 // Draw fluid
@@ -92,7 +94,7 @@ public class IngredientComponentTerminalStorageHandlerFluidStack implements IIng
                         lines.addAll(additionalTooltipLines);
                     }
                     return lines;
-                }, additionalTooltipComponent);
+                }, additionalTooltipElements);
             }
         }
     }

--- a/src/main/java/org/cyclops/integratedterminals/capability/ingredient/IngredientComponentTerminalStorageHandlerItemStack.java
+++ b/src/main/java/org/cyclops/integratedterminals/capability/ingredient/IngredientComponentTerminalStorageHandlerItemStack.java
@@ -12,6 +12,8 @@ import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.Slot;
+import com.mojang.datafixers.util.Either;
+import net.minecraft.network.chat.FormattedText;
 import net.minecraft.world.inventory.tooltip.TooltipComponent;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
@@ -70,7 +72,7 @@ public class IngredientComponentTerminalStorageHandlerItemStack implements IIngr
     public void drawInstance(GuiGraphics guiGraphics, ItemStack instance, long maxQuantity, @Nullable String label, AbstractContainerScreen gui,
                              ContainerScreenTerminalStorage.DrawLayer layer, float partialTick, int x, int y,
                              int mouseX, int mouseY, @Nullable List<Component> additionalTooltipLines,
-                             @Nullable TooltipComponent additionalTooltipComponent) {
+                             @Nullable List<Either<FormattedText, TooltipComponent>> additionalTooltipElements) {
         // Make a copy of the item to make sure that any changes in the NBT tag that the mod may make during rendering
         // does not propagate into our client-side index. Otherwise, the client may think it has different items than
         // the server, which will cause these items not to be extractable by the client from the terminal.
@@ -98,7 +100,7 @@ public class IngredientComponentTerminalStorageHandlerItemStack implements IIngr
                 }
                 addQuantityTooltip(lines, instanceCopy);
                 return lines;
-            }, additionalTooltipComponent);
+            }, additionalTooltipElements);
         }
         Lighting.setupForFlatItems();
     }

--- a/src/main/java/org/cyclops/integratedterminals/client/gui/tooltip/ClientCraftingOptionIngredientsTooltip.java
+++ b/src/main/java/org/cyclops/integratedterminals/client/gui/tooltip/ClientCraftingOptionIngredientsTooltip.java
@@ -1,96 +1,34 @@
 package org.cyclops.integratedterminals.client.gui.tooltip;
 
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphics;
-import net.minecraft.client.gui.screens.Screen;
-import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
-import net.minecraft.client.gui.screens.inventory.tooltip.ClientTooltipComponent;
-import net.minecraft.resources.ResourceLocation;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.api.distmarker.OnlyIn;
 import org.cyclops.commoncapabilities.api.ingredient.IPrototypedIngredient;
-import org.cyclops.commoncapabilities.api.ingredient.IngredientComponent;
-import org.cyclops.integratedterminals.Capabilities;
-import org.cyclops.integratedterminals.client.gui.container.ContainerScreenTerminalStorage;
 
-import javax.annotation.Nullable;
 import java.util.List;
 
 /**
  * Renders the ingredients of a {@link CraftingOptionIngredientsTooltip} as a grid of icons.
  *
- * The grid wraps after {@link #MAX_COLUMNS} icons,
- * and inputs that accept multiple alternatives are cycled through within their own slot.
+ * Inputs that accept multiple alternatives are cycled through within their own slot.
  *
  * @author rubensworks
  */
 @OnlyIn(Dist.CLIENT)
-public class ClientCraftingOptionIngredientsTooltip implements ClientTooltipComponent {
-
-    private static final ResourceLocation SLOT_SPRITE = ResourceLocation.withDefaultNamespace("container/bundle/slot");
-    private static final int SLOT_WIDTH = 18;
-    private static final int SLOT_HEIGHT = 20;
-    private static final int MAX_COLUMNS = 9;
-    private static final int MARGIN_Y = 2;
-
-    /**
-     * The number of ticks an alternative is shown before cycling to the next one.
-     */
-    private static final int TICK_DELAY = 30;
+public class ClientCraftingOptionIngredientsTooltip extends ClientCraftingOptionSlotsTooltip {
 
     private final List<List<IPrototypedIngredient<?, ?>>> ingredients;
-    private final int columns;
-    private final int rows;
 
     public ClientCraftingOptionIngredientsTooltip(CraftingOptionIngredientsTooltip tooltip) {
+        super(tooltip.ingredients().size());
         this.ingredients = tooltip.ingredients();
-        // Spread the ingredients evenly over as few rows as possible
-        this.rows = Math.max(1, (int) Math.ceil((double) this.ingredients.size() / MAX_COLUMNS));
-        this.columns = Math.max(1, (int) Math.ceil((double) this.ingredients.size() / this.rows));
     }
 
     @Override
-    public int getHeight() {
-        return this.rows * SLOT_HEIGHT + MARGIN_Y;
-    }
-
-    @Override
-    public int getWidth(Font font) {
-        return this.columns * SLOT_WIDTH;
-    }
-
-    @Override
-    public void renderImage(Font font, int x, int y, GuiGraphics guiGraphics) {
-        int tick = getTick();
-        for (int i = 0; i < this.ingredients.size(); i++) {
-            List<IPrototypedIngredient<?, ?>> alternatives = this.ingredients.get(i);
-            int slotX = x + (i % this.columns) * SLOT_WIDTH;
-            int slotY = y + (i / this.columns) * SLOT_HEIGHT;
-            guiGraphics.blitSprite(SLOT_SPRITE, slotX, slotY, SLOT_WIDTH, SLOT_HEIGHT);
-            // Cycle over the alternatives of this input
-            drawIngredient(guiGraphics, alternatives.get(tick % alternatives.size()), slotX + 1, slotY + 1);
-        }
-    }
-
-    protected static <T, M> void drawIngredient(GuiGraphics guiGraphics, IPrototypedIngredient<T, M> ingredient, int x, int y) {
-        IngredientComponent<T, M> ingredientComponent = ingredient.getComponent();
-        long quantity = ingredientComponent.getMatcher().getQuantity(ingredient.getPrototype());
-        ingredientComponent.getCapability(Capabilities.IngredientComponentTerminalStorageHandler.INGREDIENT)
-                .ifPresent(handler -> handler.drawInstance(guiGraphics, ingredient.getPrototype(), quantity, null,
-                        getContainerScreen(), ContainerScreenTerminalStorage.DrawLayer.BACKGROUND, 0,
-                        x, y, 0, 0, null));
-    }
-
-    @Nullable
-    protected static AbstractContainerScreen<?> getContainerScreen() {
-        Screen screen = Minecraft.getInstance().screen;
-        return screen instanceof AbstractContainerScreen<?> containerScreen ? containerScreen : null;
-    }
-
-    protected static int getTick() {
-        Minecraft minecraft = Minecraft.getInstance();
-        return minecraft.level == null ? 0 : (int) (minecraft.level.getGameTime() / TICK_DELAY);
+    protected void drawSlot(GuiGraphics guiGraphics, int slot, int x, int y) {
+        // Cycle over the alternatives of this input
+        List<IPrototypedIngredient<?, ?>> alternatives = this.ingredients.get(slot);
+        drawIngredient(guiGraphics, alternatives.get(getTick() % alternatives.size()), x, y);
     }
 
 }

--- a/src/main/java/org/cyclops/integratedterminals/client/gui/tooltip/ClientCraftingOptionMachinesTooltip.java
+++ b/src/main/java/org/cyclops/integratedterminals/client/gui/tooltip/ClientCraftingOptionMachinesTooltip.java
@@ -1,0 +1,30 @@
+package org.cyclops.integratedterminals.client.gui.tooltip;
+
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.world.item.ItemStack;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.api.distmarker.OnlyIn;
+
+import java.util.List;
+
+/**
+ * Renders the machines of a {@link CraftingOptionMachinesTooltip} as a grid of icons.
+ *
+ * @author rubensworks
+ */
+@OnlyIn(Dist.CLIENT)
+public class ClientCraftingOptionMachinesTooltip extends ClientCraftingOptionSlotsTooltip {
+
+    private final List<ItemStack> machines;
+
+    public ClientCraftingOptionMachinesTooltip(CraftingOptionMachinesTooltip tooltip) {
+        super(tooltip.machines().size());
+        this.machines = tooltip.machines();
+    }
+
+    @Override
+    protected void drawSlot(GuiGraphics guiGraphics, int slot, int x, int y) {
+        guiGraphics.renderItem(this.machines.get(slot), x, y);
+    }
+
+}

--- a/src/main/java/org/cyclops/integratedterminals/client/gui/tooltip/ClientCraftingOptionSlotsTooltip.java
+++ b/src/main/java/org/cyclops/integratedterminals/client/gui/tooltip/ClientCraftingOptionSlotsTooltip.java
@@ -1,0 +1,100 @@
+package org.cyclops.integratedterminals.client.gui.tooltip;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
+import net.minecraft.client.gui.screens.inventory.tooltip.ClientTooltipComponent;
+import net.minecraft.resources.ResourceLocation;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.api.distmarker.OnlyIn;
+import org.cyclops.commoncapabilities.api.ingredient.IPrototypedIngredient;
+import org.cyclops.commoncapabilities.api.ingredient.IngredientComponent;
+import org.cyclops.integratedterminals.Capabilities;
+import org.cyclops.integratedterminals.client.gui.container.ContainerScreenTerminalStorage;
+
+import javax.annotation.Nullable;
+
+/**
+ * Base class for tooltip components that render a grid of slots.
+ *
+ * The grid wraps after {@link #MAX_COLUMNS} slots,
+ * and is spread evenly over as few rows as possible.
+ *
+ * @author rubensworks
+ */
+@OnlyIn(Dist.CLIENT)
+public abstract class ClientCraftingOptionSlotsTooltip implements ClientTooltipComponent {
+
+    protected static final ResourceLocation SLOT_SPRITE = ResourceLocation.withDefaultNamespace("container/bundle/slot");
+    protected static final int SLOT_WIDTH = 18;
+    protected static final int SLOT_HEIGHT = 20;
+    protected static final int MAX_COLUMNS = 9;
+    protected static final int MARGIN_Y = 2;
+
+    /**
+     * The number of ticks an alternative is shown before cycling to the next one.
+     */
+    protected static final int TICK_DELAY = 30;
+
+    private final int slots;
+    private final int columns;
+    private final int rows;
+
+    public ClientCraftingOptionSlotsTooltip(int slots) {
+        this.slots = slots;
+        this.rows = Math.max(1, (int) Math.ceil((double) slots / MAX_COLUMNS));
+        this.columns = Math.max(1, (int) Math.ceil((double) slots / this.rows));
+    }
+
+    /**
+     * Draw the contents of the slot at the given index.
+     * @param guiGraphics The gui graphics.
+     * @param slot The slot index.
+     * @param x The X position to draw at.
+     * @param y The Y position to draw at.
+     */
+    protected abstract void drawSlot(GuiGraphics guiGraphics, int slot, int x, int y);
+
+    @Override
+    public int getHeight() {
+        return this.rows * SLOT_HEIGHT + MARGIN_Y;
+    }
+
+    @Override
+    public int getWidth(Font font) {
+        return this.columns * SLOT_WIDTH;
+    }
+
+    @Override
+    public void renderImage(Font font, int x, int y, GuiGraphics guiGraphics) {
+        for (int i = 0; i < this.slots; i++) {
+            int slotX = x + (i % this.columns) * SLOT_WIDTH;
+            int slotY = y + (i / this.columns) * SLOT_HEIGHT;
+            guiGraphics.blitSprite(SLOT_SPRITE, slotX, slotY, SLOT_WIDTH, SLOT_HEIGHT);
+            drawSlot(guiGraphics, i, slotX + 1, slotY + 1);
+        }
+    }
+
+    protected static <T, M> void drawIngredient(GuiGraphics guiGraphics, IPrototypedIngredient<T, M> ingredient, int x, int y) {
+        IngredientComponent<T, M> ingredientComponent = ingredient.getComponent();
+        long quantity = ingredientComponent.getMatcher().getQuantity(ingredient.getPrototype());
+        ingredientComponent.getCapability(Capabilities.IngredientComponentTerminalStorageHandler.INGREDIENT)
+                .ifPresent(handler -> handler.drawInstance(guiGraphics, ingredient.getPrototype(), quantity, null,
+                        getContainerScreen(), ContainerScreenTerminalStorage.DrawLayer.BACKGROUND, 0,
+                        x, y, 0, 0, null));
+    }
+
+    @Nullable
+    protected static AbstractContainerScreen<?> getContainerScreen() {
+        Screen screen = Minecraft.getInstance().screen;
+        return screen instanceof AbstractContainerScreen<?> containerScreen ? containerScreen : null;
+    }
+
+    protected static int getTick() {
+        Minecraft minecraft = Minecraft.getInstance();
+        return minecraft.level == null ? 0 : (int) (minecraft.level.getGameTime() / TICK_DELAY);
+    }
+
+}

--- a/src/main/java/org/cyclops/integratedterminals/client/gui/tooltip/CraftingOptionMachinesTooltip.java
+++ b/src/main/java/org/cyclops/integratedterminals/client/gui/tooltip/CraftingOptionMachinesTooltip.java
@@ -1,0 +1,15 @@
+package org.cyclops.integratedterminals.client.gui.tooltip;
+
+import net.minecraft.world.inventory.tooltip.TooltipComponent;
+import net.minecraft.world.item.ItemStack;
+
+import java.util.List;
+
+/**
+ * A tooltip component holding the machines that a crafting option is crafted in.
+ *
+ * @param machines The crafting machines.
+ * @author rubensworks
+ */
+public record CraftingOptionMachinesTooltip(List<ItemStack> machines) implements TooltipComponent {
+}

--- a/src/main/java/org/cyclops/integratedterminals/client/gui/tooltip/TooltipRenderHelpers.java
+++ b/src/main/java/org/cyclops/integratedterminals/client/gui/tooltip/TooltipRenderHelpers.java
@@ -31,9 +31,9 @@ public final class TooltipRenderHelpers {
     /**
      * Render a tooltip if the mouse hovers over the given region.
      *
-     * If no visual component is given, this is equivalent to {@link GuiHelpers}'s tooltip rendering.
+     * If no additional elements are given, this is equivalent to {@link GuiHelpers}'s tooltip rendering.
      * Otherwise, the tooltip is rendered by vanilla,
-     * so that the visual component can be rendered below the tooltip lines.
+     * so that visual components can be rendered below the tooltip lines.
      *
      * This must be called while rendering the foreground layer of the given gui,
      * as the given position is expected to be relative to the gui.
@@ -47,19 +47,20 @@ public final class TooltipRenderHelpers {
      * @param mouseX The mouse X position.
      * @param mouseY The mouse Y position.
      * @param linesSupplier A supplier of the tooltip lines.
-     * @param visualComponent An optional visual tooltip component.
+     * @param additionalElements Optional elements to append below the tooltip lines,
+     *                           which can mix text and visual components.
      */
     public static void renderTooltip(AbstractContainerScreen gui, GuiGraphics guiGraphics, int x, int y, int width, int height,
                                      int mouseX, int mouseY, Supplier<List<Component>> linesSupplier,
-                                     @Nullable TooltipComponent visualComponent) {
-        if (visualComponent == null) {
+                                     @Nullable List<Either<FormattedText, TooltipComponent>> additionalElements) {
+        if (additionalElements == null || additionalElements.isEmpty()) {
             GuiHelpers.renderTooltip(gui, guiGraphics.pose(), x, y, width, height, mouseX, mouseY, linesSupplier);
         } else if (isHovering(gui, x, y, width, height, mouseX, mouseY)) {
             List<Either<FormattedText, TooltipComponent>> elements = Lists.newArrayList();
             for (Component line : linesSupplier.get()) {
                 elements.add(Either.left(line));
             }
-            elements.add(Either.right(visualComponent));
+            elements.addAll(additionalElements);
 
             // Just like GuiHelpers#renderTooltip, don't write to the depth buffer,
             // so that anything that is drawn after this tooltip is not occluded by it.

--- a/src/main/java/org/cyclops/integratedterminals/core/terminalstorage/slot/TerminalStorageSlotIngredientCraftingOption.java
+++ b/src/main/java/org/cyclops/integratedterminals/core/terminalstorage/slot/TerminalStorageSlotIngredientCraftingOption.java
@@ -87,7 +87,7 @@ public class TerminalStorageSlotIngredientCraftingOption<T, M> extends TerminalS
     }
 
     /**
-     * Show the machines that this crafting option is crafted in, and the inputs that it requires,
+     * Show the inputs that this crafting option requires, and the machines that it is crafted in,
      * each as a labelled grid of icons.
      *
      * @param machines The crafting machines.
@@ -98,6 +98,12 @@ public class TerminalStorageSlotIngredientCraftingOption<T, M> extends TerminalS
     protected List<Either<FormattedText, TooltipComponent>> getTooltipElements(List<ItemStack> machines,
                                                                               List<List<IPrototypedIngredient<?, ?>>> inputs) {
         List<Either<FormattedText, TooltipComponent>> tooltipElements = Lists.newArrayList();
+        if (!inputs.isEmpty()) {
+            tooltipElements.add(Either.left(Component
+                    .translatable("gui.integratedterminals.terminal_storage.tooltip.requirements")
+                    .withStyle(ChatFormatting.YELLOW)));
+            tooltipElements.add(Either.right(new CraftingOptionIngredientsTooltip(inputs)));
+        }
         if (!machines.isEmpty()) {
             // Only a single machine can be named on the label, otherwise the icons have to speak for themselves
             tooltipElements.add(Either.left(machines.size() == 1
@@ -106,12 +112,6 @@ public class TerminalStorageSlotIngredientCraftingOption<T, M> extends TerminalS
                     : Component.translatable("gui.integratedterminals.terminal_storage.tooltip.crafting_machines")
                             .withStyle(ChatFormatting.YELLOW)));
             tooltipElements.add(Either.right(new CraftingOptionMachinesTooltip(machines)));
-        }
-        if (!inputs.isEmpty()) {
-            tooltipElements.add(Either.left(Component
-                    .translatable("gui.integratedterminals.terminal_storage.tooltip.requirements")
-                    .withStyle(ChatFormatting.YELLOW)));
-            tooltipElements.add(Either.right(new CraftingOptionIngredientsTooltip(inputs)));
         }
         return tooltipElements;
     }

--- a/src/main/java/org/cyclops/integratedterminals/core/terminalstorage/slot/TerminalStorageSlotIngredientCraftingOption.java
+++ b/src/main/java/org/cyclops/integratedterminals/core/terminalstorage/slot/TerminalStorageSlotIngredientCraftingOption.java
@@ -1,11 +1,15 @@
 package org.cyclops.integratedterminals.core.terminalstorage.slot;
 
 import com.google.common.collect.Lists;
+import com.mojang.datafixers.util.Either;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.FormattedText;
+import net.minecraft.world.inventory.tooltip.TooltipComponent;
+import net.minecraft.world.item.ItemStack;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.api.distmarker.OnlyIn;
 import org.cyclops.commoncapabilities.api.ingredient.IPrototypedIngredient;
@@ -17,6 +21,7 @@ import org.cyclops.integratedterminals.api.terminalstorage.ITerminalStorageTabCl
 import org.cyclops.integratedterminals.client.gui.container.ContainerScreenTerminalStorage;
 import org.cyclops.integratedterminals.client.gui.container.component.GuiCraftingPlan;
 import org.cyclops.integratedterminals.client.gui.tooltip.CraftingOptionIngredientsTooltip;
+import org.cyclops.integratedterminals.client.gui.tooltip.CraftingOptionMachinesTooltip;
 import org.cyclops.integratedterminals.client.gui.tooltip.TooltipRenderHelpers;
 import org.cyclops.integratedterminals.core.terminalstorage.TerminalStorageTabIngredientComponentClient;
 import org.cyclops.integratedterminals.core.terminalstorage.crafting.HandlerWrappedTerminalCraftingOption;
@@ -55,19 +60,19 @@ public class TerminalStorageSlotIngredientCraftingOption<T, M> extends TerminalS
         } else {
             // This is called for all visible slots on every frame,
             // so only determine the requirements when they are actually going to be shown.
-            List<List<IPrototypedIngredient<?, ?>>> inputs = TooltipRenderHelpers.isHovering(gui, x, y,
-                    GuiHelpers.SLOT_SIZE_INNER, GuiHelpers.SLOT_SIZE_INNER, mouseX, mouseY)
-                    ? getInputs() : List.of();
+            boolean hovering = TooltipRenderHelpers.isHovering(gui, x, y,
+                    GuiHelpers.SLOT_SIZE_INNER, GuiHelpers.SLOT_SIZE_INNER, mouseX, mouseY);
+            List<List<IPrototypedIngredient<?, ?>>> inputs = hovering ? getInputs() : List.of();
+            List<ItemStack> machines = hovering ? getCraftingOption().getCraftingOption().getCraftingMachines() : List.of();
             viewHandler.drawInstance(guiGraphics, getInstance(), maxQuantity, label, gui, layer, partialTick, x, y, mouseX, mouseY,
-                    getTooltipLines(pendingCraftingJobOutput, inputs),
-                    inputs.isEmpty() ? null : new CraftingOptionIngredientsTooltip(inputs));
+                    getTooltipLines(pendingCraftingJobOutput),
+                    getTooltipElements(machines, inputs));
         }
         drawCraftingJobOverlay(guiGraphics, layer, x, y, pendingCraftingJobOutput);
     }
 
     @OnlyIn(Dist.CLIENT)
-    protected List<Component> getTooltipLines(@Nullable PendingCraftingJobOutput<T> pendingCraftingJobOutput,
-                                              List<List<IPrototypedIngredient<?, ?>>> inputs) {
+    protected List<Component> getTooltipLines(@Nullable PendingCraftingJobOutput<T> pendingCraftingJobOutput) {
         List<Component> tooltipLines = Lists.newArrayList();
         if (pendingCraftingJobOutput != null) {
             addCraftingJobTooltipLines(tooltipLines, pendingCraftingJobOutput);
@@ -78,11 +83,37 @@ public class TerminalStorageSlotIngredientCraftingOption<T, M> extends TerminalS
             tooltipLines.add(Component.translatable("gui.integratedterminals.terminal_storage.tooltip.duration",
                     GuiCraftingPlan.getDurationValue(estimatedTickDuration)));
         }
-        if (!inputs.isEmpty()) {
-            tooltipLines.add(Component.translatable("gui.integratedterminals.terminal_storage.tooltip.requirements")
-                    .withStyle(ChatFormatting.YELLOW));
-        }
         return tooltipLines;
+    }
+
+    /**
+     * Show the machines that this crafting option is crafted in, and the inputs that it requires,
+     * each as a labelled grid of icons.
+     *
+     * @param machines The crafting machines.
+     * @param inputs The required inputs, with their alternatives.
+     * @return The tooltip elements.
+     */
+    @OnlyIn(Dist.CLIENT)
+    protected List<Either<FormattedText, TooltipComponent>> getTooltipElements(List<ItemStack> machines,
+                                                                              List<List<IPrototypedIngredient<?, ?>>> inputs) {
+        List<Either<FormattedText, TooltipComponent>> tooltipElements = Lists.newArrayList();
+        if (!machines.isEmpty()) {
+            // Only a single machine can be named on the label, otherwise the icons have to speak for themselves
+            tooltipElements.add(Either.left(machines.size() == 1
+                    ? Component.translatable("gui.integratedterminals.terminal_storage.tooltip.crafting_machine",
+                            machines.get(0).getHoverName()).withStyle(ChatFormatting.YELLOW)
+                    : Component.translatable("gui.integratedterminals.terminal_storage.tooltip.crafting_machines")
+                            .withStyle(ChatFormatting.YELLOW)));
+            tooltipElements.add(Either.right(new CraftingOptionMachinesTooltip(machines)));
+        }
+        if (!inputs.isEmpty()) {
+            tooltipElements.add(Either.left(Component
+                    .translatable("gui.integratedterminals.terminal_storage.tooltip.requirements")
+                    .withStyle(ChatFormatting.YELLOW)));
+            tooltipElements.add(Either.right(new CraftingOptionIngredientsTooltip(inputs)));
+        }
+        return tooltipElements;
     }
 
     /**

--- a/src/main/java/org/cyclops/integratedterminals/gametest/GameTestTerminalCraftingOptionMachines.java
+++ b/src/main/java/org/cyclops/integratedterminals/gametest/GameTestTerminalCraftingOptionMachines.java
@@ -1,0 +1,179 @@
+package org.cyclops.integratedterminals.gametest;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
+import net.minecraft.core.BlockPos;
+import net.minecraft.gametest.framework.GameTest;
+import net.minecraft.gametest.framework.GameTestHelper;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.item.crafting.RecipeType;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.neoforged.neoforge.gametest.GameTestHolder;
+import net.neoforged.neoforge.gametest.PrefixGameTestTemplate;
+import org.apache.commons.lang3.tuple.Triple;
+import org.cyclops.commoncapabilities.api.capability.recipehandler.IRecipeDefinition;
+import org.cyclops.commoncapabilities.api.capability.recipehandler.RecipeDefinition;
+import org.cyclops.commoncapabilities.api.ingredient.IPrototypedIngredient;
+import org.cyclops.commoncapabilities.api.ingredient.IngredientComponent;
+import org.cyclops.commoncapabilities.api.ingredient.MixedIngredients;
+import org.cyclops.commoncapabilities.api.ingredient.PrototypedIngredient;
+import org.cyclops.integratedcrafting.api.crafting.ICraftingInterface;
+import org.cyclops.integratedcrafting.core.CraftingHelpers;
+import org.cyclops.integratedcrafting.core.part.PartTypeInterfaceCraftingBase;
+import org.cyclops.integratedcrafting.gametest.GameTestHelpersIntegratedCrafting;
+import org.cyclops.integrateddynamics.api.network.INetwork;
+import org.cyclops.integrateddynamics.api.network.IPositionedAddonsNetworkIngredients;
+import org.cyclops.integrateddynamics.core.helper.NetworkHelpers;
+import org.cyclops.integratedterminals.Reference;
+import org.cyclops.integratedterminals.modcompat.integratedcrafting.TerminalCraftingOptionRecipeDefinition;
+import org.cyclops.integratedterminals.modcompat.integratedcrafting.TerminalStorageTabIngredientCraftingHandlerCraftingNetwork;
+
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Game tests for the crafting machines that are exposed by crafting options.
+ * @author rubensworks
+ */
+@GameTestHolder(Reference.MOD_ID)
+@PrefixGameTestTemplate(false)
+public class GameTestTerminalCraftingOptionMachines {
+
+    public static final BlockPos POS = BlockPos.ZERO.offset(2, 0, 2);
+    public static final int TIMEOUT = 2000;
+
+    private static IRecipeDefinition createRecipe() {
+        List<List<IPrototypedIngredient<ItemStack, Integer>>> inputs = Lists.newArrayList();
+        inputs.add(Lists.newArrayList(new PrototypedIngredient<>(IngredientComponent.ITEMSTACK,
+                new ItemStack(Items.OAK_PLANKS),
+                IngredientComponent.ITEMSTACK.getMatcher().getExactMatchNoQuantityCondition())));
+        return RecipeDefinition.ofIngredients(IngredientComponent.ITEMSTACK, inputs,
+                MixedIngredients.ofInstance(IngredientComponent.ITEMSTACK, new ItemStack(Items.STICK, 4)));
+    }
+
+    /**
+     * The machines of a crafting option must survive being sent to the client.
+     */
+    @GameTest(template = "empty", templateNamespace = "cyclopscore")
+    public void testCraftingMachinesSerialization(GameTestHelper helper) {
+        TerminalStorageTabIngredientCraftingHandlerCraftingNetwork handler =
+                new TerminalStorageTabIngredientCraftingHandlerCraftingNetwork();
+        TerminalCraftingOptionRecipeDefinition<ItemStack, Integer> craftingOption =
+                new TerminalCraftingOptionRecipeDefinition<>(IngredientComponent.ITEMSTACK, createRecipe(), -1,
+                        Lists.newArrayList(new ItemStack(Items.FURNACE), new ItemStack(Items.CRAFTING_TABLE)));
+
+        CompoundTag tag = handler.serializeCraftingOption(helper.getLevel().registryAccess(), craftingOption);
+        TerminalCraftingOptionRecipeDefinition<?, ?> deserialized = handler.deserializeCraftingOption(
+                helper.getLevel().registryAccess(), IngredientComponent.ITEMSTACK, tag);
+
+        List<ItemStack> machines = deserialized.getCraftingMachines();
+        helper.assertValueEqual(machines.size(), 2, "Crafting machine count is incorrect");
+        helper.assertValueEqual(machines.get(0).getItem(), Items.FURNACE, "First crafting machine is incorrect");
+        helper.assertValueEqual(machines.get(1).getItem(), Items.CRAFTING_TABLE, "Second crafting machine is incorrect");
+
+        helper.succeed();
+    }
+
+    /**
+     * A crafting option without machines must not write them,
+     * so that nothing is sent for handlers that can not determine them.
+     */
+    @GameTest(template = "empty", templateNamespace = "cyclopscore")
+    public void testCraftingMachinesSerializationEmpty(GameTestHelper helper) {
+        TerminalStorageTabIngredientCraftingHandlerCraftingNetwork handler =
+                new TerminalStorageTabIngredientCraftingHandlerCraftingNetwork();
+        TerminalCraftingOptionRecipeDefinition<ItemStack, Integer> craftingOption =
+                new TerminalCraftingOptionRecipeDefinition<>(IngredientComponent.ITEMSTACK, createRecipe());
+
+        CompoundTag tag = handler.serializeCraftingOption(helper.getLevel().registryAccess(), craftingOption);
+        helper.assertFalse(tag.contains("craftingMachines"), "Expected no crafting machines to be serialized");
+
+        TerminalCraftingOptionRecipeDefinition<?, ?> deserialized = handler.deserializeCraftingOption(
+                helper.getLevel().registryAccess(), IngredientComponent.ITEMSTACK, tag);
+        helper.assertTrue(deserialized.getCraftingMachines().isEmpty(), "Expected no crafting machines");
+
+        helper.succeed();
+    }
+
+    /**
+     * Check the machines that are determined for the first recipe that the network exposes.
+     *
+     * @param helper The game test helper.
+     * @param attuned If an attuned crafting interface should be used.
+     * @param crafters The machines to place before the crafting interfaces.
+     * @param expectedInterfaces The expected number of interfaces that expose the recipe.
+     * @param expectedMachine The expected machine item.
+     */
+    protected void testCraftingMachinesInNetwork(GameTestHelper helper, boolean attuned, Block[] crafters,
+                                                 int expectedInterfaces, Item expectedMachine,
+                                                 RecipeType<?> recipeType, ResourceLocation recipeName) {
+        GameTestHelpersIntegratedCrafting.INetworkPositions<PartTypeInterfaceCraftingBase.State<?, ?>> positions =
+                GameTestHelpersIntegratedCrafting.createBasicNetwork(helper, POS, attuned, crafters);
+
+        // Add the recipe to every crafting interface.
+        // Attuned interfaces derive their recipes from their machine, so this is a no-op for those.
+        for (int i = 0; i < crafters.length; i++) {
+            positions.interfaceRecipeAdders().get(i).accept(Triple.of(0, recipeType, recipeName));
+        }
+
+        helper.succeedWhen(() -> {
+            INetwork network = NetworkHelpers.getNetwork(helper.getLevel(), helper.absolutePos(POS), null)
+                    .orElseThrow(() -> new IllegalStateException("Could not find a network"));
+            Multimap<IRecipeDefinition, ICraftingInterface> recipeCraftingInterfaces = CraftingHelpers
+                    .getCraftingNetworkChecked(network)
+                    .getRecipeCraftingInterfaces(IPositionedAddonsNetworkIngredients.DEFAULT_CHANNEL);
+            helper.assertFalse(recipeCraftingInterfaces.isEmpty(), "The network exposes no recipes yet");
+
+            IRecipeDefinition recipe = recipeCraftingInterfaces.keySet().iterator().next();
+            Collection<ICraftingInterface> craftingInterfaces = recipeCraftingInterfaces.get(recipe);
+            helper.assertValueEqual(craftingInterfaces.size(), expectedInterfaces,
+                    "Crafting interface count is incorrect");
+
+            List<ItemStack> machines = TerminalStorageTabIngredientCraftingHandlerCraftingNetwork
+                    .getCraftingMachines(craftingInterfaces, Maps.newIdentityHashMap());
+            helper.assertValueEqual(machines.size(), 1, "Crafting machine count is incorrect");
+            helper.assertValueEqual(machines.get(0).getItem(), expectedMachine, "Crafting machine is incorrect");
+        });
+    }
+
+    @GameTest(template = "empty10", templateNamespace = Reference.MOD_ID, timeoutTicks = TIMEOUT)
+    public void testCraftingMachinesInNetworkCraftingTable(GameTestHelper helper) {
+        testCraftingMachinesInNetwork(helper, false, new Block[]{Blocks.CRAFTING_TABLE}, 1, Items.CRAFTING_TABLE,
+                RecipeType.CRAFTING, ResourceLocation.fromNamespaceAndPath("minecraft", "chest"));
+    }
+
+    @GameTest(template = "empty10", templateNamespace = Reference.MOD_ID, timeoutTicks = TIMEOUT)
+    public void testCraftingMachinesInNetworkFurnace(GameTestHelper helper) {
+        testCraftingMachinesInNetwork(helper, false, new Block[]{Blocks.FURNACE}, 1, Items.FURNACE,
+                RecipeType.SMELTING, ResourceLocation.fromNamespaceAndPath("minecraft", "iron_ingot_from_smelting_raw_iron"));
+    }
+
+    @GameTest(template = "empty10", templateNamespace = Reference.MOD_ID, timeoutTicks = TIMEOUT)
+    public void testCraftingMachinesInNetworkAttunedCraftingTable(GameTestHelper helper) {
+        testCraftingMachinesInNetwork(helper, true, new Block[]{Blocks.CRAFTING_TABLE}, 1, Items.CRAFTING_TABLE,
+                RecipeType.CRAFTING, ResourceLocation.fromNamespaceAndPath("minecraft", "chest"));
+    }
+
+    @GameTest(template = "empty10", templateNamespace = Reference.MOD_ID, timeoutTicks = TIMEOUT)
+    public void testCraftingMachinesInNetworkAttunedFurnace(GameTestHelper helper) {
+        testCraftingMachinesInNetwork(helper, true, new Block[]{Blocks.FURNACE}, 1, Items.FURNACE,
+                RecipeType.SMELTING, ResourceLocation.fromNamespaceAndPath("minecraft", "iron_ingot_from_smelting_raw_iron"));
+    }
+
+    /**
+     * Two interfaces that target the same machine type must only show that machine once.
+     */
+    @GameTest(template = "empty10", templateNamespace = Reference.MOD_ID, timeoutTicks = TIMEOUT)
+    public void testCraftingMachinesInNetworkDeduplicated(GameTestHelper helper) {
+        testCraftingMachinesInNetwork(helper, false, new Block[]{Blocks.CRAFTING_TABLE, Blocks.CRAFTING_TABLE},
+                2, Items.CRAFTING_TABLE,
+                RecipeType.CRAFTING, ResourceLocation.fromNamespaceAndPath("minecraft", "chest"));
+    }
+
+}

--- a/src/main/java/org/cyclops/integratedterminals/modcompat/integratedcrafting/TerminalCraftingOptionRecipeDefinition.java
+++ b/src/main/java/org/cyclops/integratedterminals/modcompat/integratedcrafting/TerminalCraftingOptionRecipeDefinition.java
@@ -2,12 +2,14 @@ package org.cyclops.integratedterminals.modcompat.integratedcrafting;
 
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import net.minecraft.world.item.ItemStack;
 import org.cyclops.commoncapabilities.api.capability.recipehandler.IRecipeDefinition;
 import org.cyclops.commoncapabilities.api.ingredient.IPrototypedIngredient;
 import org.cyclops.commoncapabilities.api.ingredient.IngredientComponent;
 import org.cyclops.integratedterminals.api.terminalstorage.crafting.ITerminalCraftingOption;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -23,6 +25,7 @@ public class TerminalCraftingOptionRecipeDefinition<T, M> implements ITerminalCr
     private final IngredientComponent<T, M> ingredientComponent;
     private final IRecipeDefinition prioritizedRecipe;
     private final long estimatedTickDuration;
+    private final List<ItemStack> craftingMachines;
 
     @Deprecated // TODO: rm in next major
     public TerminalCraftingOptionRecipeDefinition(IngredientComponent<T, M> ingredientComponent,
@@ -33,14 +36,27 @@ public class TerminalCraftingOptionRecipeDefinition<T, M> implements ITerminalCr
     public TerminalCraftingOptionRecipeDefinition(IngredientComponent<T, M> ingredientComponent,
                                                   IRecipeDefinition prioritizedRecipe,
                                                   long estimatedTickDuration) {
+        this(ingredientComponent, prioritizedRecipe, estimatedTickDuration, Collections.emptyList());
+    }
+
+    public TerminalCraftingOptionRecipeDefinition(IngredientComponent<T, M> ingredientComponent,
+                                                  IRecipeDefinition prioritizedRecipe,
+                                                  long estimatedTickDuration,
+                                                  List<ItemStack> craftingMachines) {
         this.ingredientComponent = ingredientComponent;
         this.prioritizedRecipe = prioritizedRecipe;
         this.estimatedTickDuration = estimatedTickDuration;
+        this.craftingMachines = craftingMachines;
     }
 
     @Override
     public long getEstimatedTickDuration() {
         return estimatedTickDuration;
+    }
+
+    @Override
+    public List<ItemStack> getCraftingMachines() {
+        return craftingMachines;
     }
 
     @Override

--- a/src/main/java/org/cyclops/integratedterminals/modcompat/integratedcrafting/TerminalStorageTabIngredientCraftingHandlerCraftingNetwork.java
+++ b/src/main/java/org/cyclops/integratedterminals/modcompat/integratedcrafting/TerminalStorageTabIngredientCraftingHandlerCraftingNetwork.java
@@ -1,13 +1,18 @@
 package org.cyclops.integratedterminals.modcompat.integratedcrafting;
 
+import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
 import com.mojang.authlib.GameProfile;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.IntTag;
+import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.item.ItemStack;
 import net.neoforged.neoforge.server.ServerLifecycleHooks;
 import org.apache.logging.log4j.Level;
 import org.cyclops.commoncapabilities.api.capability.recipehandler.IRecipeDefinition;
@@ -71,25 +76,64 @@ public class TerminalStorageTabIngredientCraftingHandlerCraftingNetwork
         IngredientComponent<T, M> ingredientComponent = tab.getIngredientNetwork().getComponent();
         IRecipeIndex recipeIndex = getRecipeIndex(tab.getNetwork(), channel);
         ICraftingNetwork craftingNetwork = CraftingHelpers.getCraftingNetwork(tab.getNetwork()).orElse(null);
+        Multimap<IRecipeDefinition, ICraftingInterface> recipeCraftingInterfaces = craftingNetwork == null
+                ? ImmutableMultimap.of() : craftingNetwork.getRecipeCraftingInterfaces(channel);
+        // Multiple recipes are commonly exposed by the same crafting interface,
+        // so only resolve the machine of each interface once.
+        Map<ICraftingInterface, ItemStack> machineCache = Maps.newIdentityHashMap();
         Iterable<IRecipeDefinition> recipes = () -> recipeIndex.getRecipes(ingredientComponent, instance, matchCondition);
         return StreamSupport.stream(recipes.spliterator(), false)
                 .map((recipe) -> new TerminalCraftingOptionRecipeDefinition<>(ingredientComponent, recipe,
-                        craftingNetwork == null ? -1 : craftingNetwork.getEstimatedRecipeDuration(channel, recipe)))
+                        craftingNetwork == null ? -1 : craftingNetwork.getEstimatedRecipeDuration(channel, recipe),
+                        getCraftingMachines(recipeCraftingInterfaces.get(recipe), machineCache)))
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * Determine the distinct machines that are targeted by the given crafting interfaces.
+     * @param craftingInterfaces The crafting interfaces that expose a recipe.
+     * @param machineCache A cache of machines by crafting interface.
+     * @return The machines, without duplicates.
+     */
+    public static List<ItemStack> getCraftingMachines(Collection<ICraftingInterface> craftingInterfaces,
+                                                      Map<ICraftingInterface, ItemStack> machineCache) {
+        List<ItemStack> craftingMachines = Lists.newArrayList();
+        for (ICraftingInterface craftingInterface : craftingInterfaces) {
+            ItemStack machine = machineCache.computeIfAbsent(craftingInterface, ICraftingInterface::getTargetMachineItem);
+            // Different interfaces can target the same machine type, which we only want to show once
+            if (!machine.isEmpty() && craftingMachines.stream()
+                    .noneMatch(existing -> ItemStack.isSameItemSameComponents(existing, machine))) {
+                craftingMachines.add(machine);
+            }
+        }
+        return craftingMachines;
     }
 
     @Override
     public CompoundTag serializeCraftingOption(HolderLookup.Provider lookupProvider, TerminalCraftingOptionRecipeDefinition craftingOption) {
         CompoundTag tag = IRecipeDefinition.serialize(lookupProvider, craftingOption.getRecipe());
         tag.putLong("estimatedTickDuration", craftingOption.getEstimatedTickDuration());
+        List<ItemStack> craftingMachines = craftingOption.getCraftingMachines();
+        if (!craftingMachines.isEmpty()) {
+            ListTag craftingMachinesTag = new ListTag();
+            for (ItemStack craftingMachine : craftingMachines) {
+                craftingMachinesTag.add(craftingMachine.save(lookupProvider));
+            }
+            tag.put("craftingMachines", craftingMachinesTag);
+        }
         return tag;
     }
 
     @Override
     public <T, M> TerminalCraftingOptionRecipeDefinition deserializeCraftingOption(HolderLookup.Provider lookupProvider, IngredientComponent<T, M> ingredientComponent, CompoundTag tag) throws IllegalArgumentException {
+        List<ItemStack> craftingMachines = Lists.newArrayList();
+        for (Tag craftingMachineTag : tag.getList("craftingMachines", Tag.TAG_COMPOUND)) {
+            ItemStack.parse(lookupProvider, craftingMachineTag).ifPresent(craftingMachines::add);
+        }
         return new TerminalCraftingOptionRecipeDefinition<>(ingredientComponent,
                 IRecipeDefinition.deserialize(lookupProvider, tag),
-                tag.contains("estimatedTickDuration", Tag.TAG_LONG) ? tag.getLong("estimatedTickDuration") : -1);
+                tag.contains("estimatedTickDuration", Tag.TAG_LONG) ? tag.getLong("estimatedTickDuration") : -1,
+                craftingMachines);
     }
 
     @Override

--- a/src/main/java/org/cyclops/integratedterminals/proxy/ClientProxy.java
+++ b/src/main/java/org/cyclops/integratedterminals/proxy/ClientProxy.java
@@ -16,7 +16,9 @@ import org.cyclops.cyclopscore.proxy.ClientProxyComponent;
 import org.cyclops.integratedterminals.IntegratedTerminals;
 import org.cyclops.integratedterminals.Reference;
 import org.cyclops.integratedterminals.client.gui.tooltip.ClientCraftingOptionIngredientsTooltip;
+import org.cyclops.integratedterminals.client.gui.tooltip.ClientCraftingOptionMachinesTooltip;
 import org.cyclops.integratedterminals.client.gui.tooltip.CraftingOptionIngredientsTooltip;
+import org.cyclops.integratedterminals.client.gui.tooltip.CraftingOptionMachinesTooltip;
 import org.cyclops.integratedterminals.item.ItemTerminalStoragePortable;
 import org.cyclops.integratedterminals.network.packet.TerminalStorageIngredientItemOpenGenericPacket;
 import org.lwjgl.glfw.GLFW;
@@ -69,6 +71,7 @@ public class ClientProxy extends ClientProxyComponent {
 
     public void registerClientTooltipComponentFactories(RegisterClientTooltipComponentFactoriesEvent event) {
         event.register(CraftingOptionIngredientsTooltip.class, ClientCraftingOptionIngredientsTooltip::new);
+        event.register(CraftingOptionMachinesTooltip.class, ClientCraftingOptionMachinesTooltip::new);
     }
 
     @Override

--- a/src/main/resources/assets/integratedterminals/lang/en_us.json
+++ b/src/main/resources/assets/integratedterminals/lang/en_us.json
@@ -18,6 +18,8 @@
     "gui.integratedterminals.terminal_storage.no_tabs": "No tabs available. Connect storage to this network with an interface.",
     "gui.integratedterminals.terminal_storage.ender_chest": "Ender Storage",
     "gui.integratedterminals.terminal_storage.craft": "craft",
+    "gui.integratedterminals.terminal_storage.tooltip.crafting_machine": "Crafted In: %s",
+    "gui.integratedterminals.terminal_storage.tooltip.crafting_machines": "Crafted In:",
     "gui.integratedterminals.terminal_storage.tooltip.requirements": "Crafting Requirements:",
     "gui.integratedterminals.terminal_storage.tooltip.crafting": "Being crafted: %s",
     "gui.integratedterminals.terminal_storage.tooltip.duration": "Estimated: %s per craft",


### PR DESCRIPTION
Closes #181

Hovering a craftable in the storage terminal now says which machine it is crafted in, by name and by icon, above the crafting requirements.

```
Iron Ingot
Quantity: 1
Crafted In: Furnace
[furnace]
Crafting Requirements:
[raw iron]
```

When several distinct machines expose the same recipe, the label drops the name and the icons speak for themselves (`Crafted In:` followed by one icon per machine). Interfaces targeting the same machine type are shown once.

### How it works

The machines are resolved server-side in `TerminalStorageTabIngredientCraftingHandlerCraftingNetwork`, once per channel, from `ICraftingNetwork#getRecipeCraftingInterfaces` and the new `ICraftingInterface#getTargetMachineItem()`. Each interface's machine is resolved at most once per call, since many recipes are commonly exposed by the same interface. They are serialized alongside the recipe and carried to the client on the crafting option, exposed generically through `ITerminalCraftingOption#getCraftingMachines()` (defaulting to empty, so handlers that cannot determine them are unaffected and write nothing).

To give the machines and the requirements each their own labelled icon grid, tooltips are now built as a `List<Either<FormattedText, TooltipComponent>>` that mixes text and visual components, rather than a list of lines plus a single trailing component. That changes the last parameter of `IIngredientComponentTerminalStorageHandler#drawInstance`; the shared slot-grid rendering moved into a `ClientCraftingOptionSlotsTooltip` base class that both grids extend.

### Depends on

[CyclopsMC/IntegratedCrafting#225](https://github.com/CyclopsMC/IntegratedCrafting/pull/225), which adds `ICraftingInterface#getTargetMachineItem()`. **CI here cannot pass until that is merged and released, and `integratedcrafting_version` in `gradle.properties` is bumped to a build containing it.** Locally this was built and tested against IntegratedCrafting `1.5.0-DEV` via `integratedcrafting_version_local` in `secrets.properties`.

### Testing

New game tests in `GameTestTerminalCraftingOptionMachines`: serialization round-trip (with and without machines), machine resolution from a live network for the regular and the attuned crafting interface against a crafting table and a furnace, and deduplication across two interfaces on the same machine type.

```
All 41 required tests passed :)
```

`./gradlew build` and `./gradlew runGameTestServer` both pass.

Verified in a dev client with clientdevbridge-cli, for the regular and the attuned crafting interface against a crafting table and a furnace, plus the multiple-machine case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RM86uiqD4soLkMyjC9Eeid

---
_Generated by [Claude Code](https://claude.ai/code/session_01RM86uiqD4soLkMyjC9Eeid)_